### PR TITLE
Adding ModbusTCPRequest class

### DIFF
--- a/components/modbus_ble_bridge/modbus_ble_bridge.h
+++ b/components/modbus_ble_bridge/modbus_ble_bridge.h
@@ -43,10 +43,8 @@ class ModbusBleBridge : public Component, public ble_client::BLEClientNode {
   int server_fd_ = -1;
   int client_fd_ = -1;
 #endif
-  std::vector<uint8_t> modbus_request_;
   std::vector<uint8_t> modbus_frame_response_;
   int total_registers_ = 0;
-  uint16_t requested_regs_{0};
   int errlen_ = 0;
   int c_ = 0;
   int total_calls_ = 0;

--- a/components/modbus_ble_bridge/modbus_types.cpp
+++ b/components/modbus_ble_bridge/modbus_types.cpp
@@ -1,0 +1,84 @@
+#include "modbus_types.h"
+
+namespace modbus_saj {
+
+// Constructor implementation
+ModbusTCPRequest::ModbusTCPRequest(const std::vector<uint8_t>& request) {
+  // Parse header fields
+  transaction_identifier[0] = request[0];
+  transaction_identifier[1] = request[1];
+  protocol_identifier[0] = request[2];
+  protocol_identifier[1] = request[3];
+  length[0] = request[4];
+  length[1] = request[5];
+  unit_id = request[6];
+  function_code = request[7];
+  address[0] = request[8];
+  address[1] = request[9];
+  number_registers[0] = request[10];
+  number_registers[1] = request[11];
+}
+
+// Getter method implementations
+uint8_t ModbusTCPRequest::getFunctionCode() const {
+  return function_code;
+}
+
+uint8_t ModbusTCPRequest::getUnitId() const {
+  return unit_id;
+}
+
+uint16_t ModbusTCPRequest::getTransactionId() const {
+  return (transaction_identifier[0] << 8) + transaction_identifier[1] - 1;
+}
+
+uint16_t ModbusTCPRequest::getAddress() const {
+  return (address[0] << 8) | address[1];
+}
+
+uint16_t ModbusTCPRequest::getNumberOfRegisters() const {
+  return (number_registers[0] << 8) + (2 * number_registers[1]) + 3;
+}
+
+const uint8_t* ModbusTCPRequest::getTransactionIdentifierBytes() const {
+  return transaction_identifier;
+}
+
+const uint8_t* ModbusTCPRequest::getProtocolIdentifierBytes() const {
+  return protocol_identifier;
+}
+
+const uint8_t* ModbusTCPRequest::getLengthBytes() const {
+  return length;
+}
+
+const uint8_t* ModbusTCPRequest::getAddressBytes() const {
+  return address;
+}
+
+const uint8_t* ModbusTCPRequest::getNumberRegistersBytes() const {
+  return number_registers;
+}
+
+void ModbusTCPRequest::printDebugInfo() const {
+  ESP_LOGD(kModbusTypesTag, "Modbus TCP Frame Debug Info:");
+  ESP_LOGD(kModbusTypesTag, "  Transaction ID: 0x%02X%02X (%d)", 
+           transaction_identifier[0], transaction_identifier[1], 
+           getTransactionId());
+  ESP_LOGD(kModbusTypesTag, "  Protocol ID: 0x%02X%02X", 
+           protocol_identifier[0], protocol_identifier[1]);
+  ESP_LOGD(kModbusTypesTag, "  Length: 0x%02X%02X (%d bytes)", 
+           length[0], length[1], 
+           (length[0] << 8) | length[1]);
+  ESP_LOGD(kModbusTypesTag, "  Unit ID: 0x%02X (%d)", 
+           unit_id, unit_id);
+  ESP_LOGD(kModbusTypesTag, "  Function Code: 0x%02X (%d)", 
+           function_code, function_code);
+  ESP_LOGD(kModbusTypesTag, "  Address: 0x%02X%02X (%d)", 
+           address[0], address[1], getAddress());
+  ESP_LOGD(kModbusTypesTag, "  Number of Registers: 0x%02X%02X (%d)", 
+           number_registers[0], number_registers[1], 
+           getNumberOfRegisters());
+}
+
+}  // namespace modbus_saj

--- a/components/modbus_ble_bridge/modbus_types.h
+++ b/components/modbus_ble_bridge/modbus_types.h
@@ -1,0 +1,51 @@
+#ifndef MODBUS_TYPES_H_
+#define MODBUS_TYPES_H_
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+#include "esphome/core/log.h"
+
+namespace modbus_saj {
+
+static const char* const kModbusTypesTag = "modbus_types";
+
+class ModbusTCPRequest {
+ protected:
+  // Modbus TCP header fields
+  uint8_t transaction_identifier[2];
+  uint8_t protocol_identifier[2];
+  uint8_t length[2];
+  uint8_t unit_id;
+  uint8_t function_code;
+  uint8_t address[2];
+  uint8_t number_registers[2];
+
+ public:
+  // Default constructor
+  ModbusTCPRequest() = default;
+  
+  // Constructor that takes a byte array
+  explicit ModbusTCPRequest(const std::vector<uint8_t>& request);
+
+  // Getter methods for accessing parsed fields
+  uint8_t getFunctionCode() const;
+  uint8_t getUnitId() const;
+  uint16_t getTransactionId() const;
+  uint16_t getAddress() const;
+  uint16_t getNumberOfRegisters() const;
+
+  // Get raw byte arrays (by reference - no copying!)
+  const uint8_t* getTransactionIdentifierBytes() const;
+  const uint8_t* getProtocolIdentifierBytes() const;
+  const uint8_t* getLengthBytes() const;
+  const uint8_t* getAddressBytes() const;
+  const uint8_t* getNumberRegistersBytes() const;
+
+  // Debug method using ESPHome logging
+  void printDebugInfo() const;
+};
+}  // namespace modbus_saj
+
+#endif // MODBUS_TYPES_H_


### PR DESCRIPTION
- Removing unused class attributes
- Refactored socket read logic
- Using new abstraction ModbusTCPRequest
- Avoid using several local variables already available in the ModbusTCPRequest object